### PR TITLE
ollama test

### DIFF
--- a/Dio.ipynb
+++ b/Dio.ipynb
@@ -2,7 +2,7 @@
   "cells": [
     {
       "cell_type": "code",
-      "execution_count": 41,
+      "execution_count": null,
       "metadata": {
         "id": "H172JMehMVcp"
       },
@@ -11,7 +11,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 27,
+      "execution_count": null,
       "metadata": {
         "id": "eOAjFiB8MpKI"
       },
@@ -23,7 +23,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 64,
+      "execution_count": null,
       "metadata": {
         "id": "OFFIZJ41UIA8"
       },
@@ -45,7 +45,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 65,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/",
@@ -91,7 +91,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 58,
+      "execution_count": null,
       "metadata": {
         "id": "c2cdA0hpUjFN"
       },
@@ -155,7 +155,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 45,
+      "execution_count": null,
       "metadata": {
         "id": "RhooKKn1UrwO",
         "colab": {
@@ -212,7 +212,7 @@
       "metadata": {
         "id": "ZniJ1rYDGNgc"
       },
-      "execution_count": 78,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -226,7 +226,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 79,
+      "execution_count": null,
       "metadata": {
         "id": "GS6ono6GaPvT"
       },
@@ -289,7 +289,7 @@
       "metadata": {
         "id": "ngSczWTcmvNh"
       },
-      "execution_count": 80,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -327,7 +327,7 @@
         "id": "Mr7WUMZtqzsq",
         "outputId": "62c510f1-a792-433f-8c1d-50c1748ba216"
       },
-      "execution_count": 81,
+      "execution_count": null,
       "outputs": [
         {
           "output_type": "stream",
@@ -373,11 +373,14 @@
     },
     {
       "cell_type": "code",
-      "source": [],
+      "source": [
+        "#Using_ollama\n",
+        ""
+      ],
       "metadata": {
         "id": "uqi1m9qmu3LK"
       },
-      "execution_count": 41,
+      "execution_count": null,
       "outputs": []
     },
     {
@@ -386,17 +389,48 @@
       "metadata": {
         "id": "QRE1_o7pv3l2"
       },
-      "execution_count": 41,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 41,
+      "execution_count": 5,
       "metadata": {
-        "id": "iYTt5DHQVISp"
+        "id": "iYTt5DHQVISp",
+        "colab": {
+          "base_uri": "https://localhost:8080/"
+        },
+        "outputId": "4a05b9f6-8095-436a-b6a2-f5bd1241b03e"
       },
-      "outputs": [],
-      "source": []
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "Raw Response Text:\n",
+            "\n",
+            "\n",
+            "Error: Could not decode JSON from the response.\n",
+            "Please check the server logs for the Ollama instance.\n"
+          ]
+        }
+      ],
+      "source": [
+        "import requests\n",
+        "\n",
+        "OLLAMA_URL = \"https://43b6-62-49-23-111.ngrok-free.app\"\n",
+        "\n",
+        "payload = {\n",
+        "    \"model\": \"llama3.2\",\n",
+        "    \"prompt\": \"Tell me a fun fact about the moon.\",\n",
+        "}\n",
+        "\n",
+        "response = requests.post(f\"{OLLAMA_URL}/api/generate\", json=payload)\n",
+        "\n",
+        "# Print the raw response text to debug\n",
+        "print(\"Raw Response Text:\")\n",
+        "print(response.text)\n"
+      ]
     },
     {
       "cell_type": "code",
@@ -404,12 +438,12 @@
       "metadata": {
         "id": "hQR4WdAuu1-9"
       },
-      "execution_count": 41,
+      "execution_count": null,
       "outputs": []
     },
     {
       "cell_type": "code",
-      "execution_count": 41,
+      "execution_count": null,
       "metadata": {
         "id": "3NTATtePcd98"
       },
@@ -418,7 +452,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 68,
+      "execution_count": null,
       "metadata": {
         "id": "bANPEz0eMtEr"
       },
@@ -427,7 +461,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 41,
+      "execution_count": null,
       "metadata": {
         "id": "KfY0F3kEVdak"
       },
@@ -436,7 +470,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 41,
+      "execution_count": null,
       "metadata": {
         "id": "XNQf08FQepri"
       },
@@ -457,7 +491,7 @@
     "colab": {
       "provenance": [],
       "toc_visible": true,
-      "authorship_tag": "ABX9TyOZzFIt1aQ9Oonrxcr4C6RH"
+      "authorship_tag": "ABX9TyPfCifuzY90V5ghJVbqBwRA"
     },
     "kernelspec": {
       "display_name": "Python 3",


### PR DESCRIPTION
## Summary by Sourcery

Reset the Jupyter notebook by clearing execution counts for reproducibility and introduce an Ollama API usage snippet to test integration.

New Features:
- Add an Ollama API example in the notebook to generate and print a fun fact about the moon.

Enhancements:
- Clear execution_count values across all code cells to reset the notebook state.